### PR TITLE
change rootproject.name in settings.gradle

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "Kaster"
+rootProject.name = "kaster"
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 


### PR DESCRIPTION
This is a code correction for Issue 94. An error occurred when I tried to do grandle sync, so I corrected rootproject.name in settings.gradle.